### PR TITLE
Improve paper data and use unique abstracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Interactive 3D visualization of research topics and papers, featuring a Matrix-s
 - Matrix-style falling characters that transform into network visualizations
 - Interactive 3D topic exploration
 - Connected paper visualization for each research topic
+- Click a topic to reveal a list of sample papers with abstracts
 - Dynamic transitions and animations
 - Responsive design
 

--- a/src/components/Paper.tsx
+++ b/src/components/Paper.tsx
@@ -12,19 +12,15 @@ const MobilePaper = dynamic(() => import("./mobile/MobilePaper"), { ssr: false }
 
 type PaperProps = {
   title: string
+  abstract: string
   position: [number, number, number]
   isVisible: boolean
   topicPosition: [number, number, number]
   onPaperClick?: () => void
 }
 
-// Example abstract (replace with real content later)
-const SAMPLE_ABSTRACT = `This paper explores the intersection of artificial intelligence and human cognition, 
-focusing on emergent behaviors in multi-agent systems. Through extensive experimentation and theoretical analysis, 
-we demonstrate novel approaches to agent-based learning and collective intelligence. Our findings suggest significant 
-implications for the future of human-AI collaboration and distributed systems architecture.`
 
-export default function Paper({ title, position, isVisible, topicPosition, onPaperClick }: PaperProps) {
+export default function Paper({ title, abstract, position, isVisible, topicPosition, onPaperClick }: PaperProps) {
   const lineRef = useRef<THREE.Line>(null!)
   const particlesRef = useRef<THREE.Points>(null!)
   const groupRef = useRef<THREE.Group>(null!)
@@ -110,7 +106,7 @@ export default function Paper({ title, position, isVisible, topicPosition, onPap
       />
       <PaperDetail
         title={title}
-        abstract={SAMPLE_ABSTRACT}
+        abstract={abstract}
         isActive={showDetail}
         paperPosition={position}
         onClose={() => setShowDetail(false)}

--- a/src/components/TopicWords.tsx
+++ b/src/components/TopicWords.tsx
@@ -11,6 +11,7 @@ type Topic = {
   position: [number, number, number]
   papers: Array<{
     title: string
+    abstract: string
     position: [number, number, number]
   }>
 }
@@ -22,58 +23,190 @@ type TopicWordsProps = {
 }
 
 const topicData: Topic[] = [
-  { 
+  {
     name: "Agents",
     position: [-8, 4, 0],
     papers: [
-      { title: "Emergent Agent Behavior", position: [-12, 6, 2] },
-      { title: "Multi-Agent Systems", position: [-10, 2, -2] },
-      { title: "Agent-Based Learning", position: [-6, 5, -3] }
+      {
+        title: "Emergent Agent Behavior",
+        abstract: "Study of spontaneous coordination among autonomous agents.",
+        position: [-12, 6, 2]
+      },
+      {
+        title: "Multi-Agent Systems",
+        abstract: "Overview of architectures enabling many agents to cooperate.",
+        position: [-10, 2, -2]
+      },
+      {
+        title: "Agent-Based Learning",
+        abstract: "Examines reinforcement strategies for adaptive agents.",
+        position: [-6, 5, -3]
+      },
+      {
+        title: "Coordinated Autonomy",
+        abstract: "Techniques for balancing independence and teamwork.",
+        position: [-9, 3, 1]
+      },
+      {
+        title: "Ethical Agency",
+        abstract: "Considers moral frameworks for autonomous decision making.",
+        position: [-7, 4, -1]
+      }
     ]
   },
-  { 
+  {
     name: "Embeddings",
     position: [8, -2, 2],
     papers: [
-      { title: "Vector Representations", position: [12, 0, 4] },
-      { title: "Semantic Spaces", position: [6, -4, 0] },
-      { title: "Embedding Techniques", position: [10, -1, -2] }
+      {
+        title: "Vector Representations",
+        abstract: "Survey of vector encoding methods in NLP.",
+        position: [12, 0, 4]
+      },
+      {
+        title: "Semantic Spaces",
+        abstract: "Describes embedding spaces capturing concept relationships.",
+        position: [6, -4, 0]
+      },
+      {
+        title: "Embedding Techniques",
+        abstract: "Comparison of approaches for generating embeddings.",
+        position: [10, -1, -2]
+      },
+      {
+        title: "Cross-Lingual Mapping",
+        abstract: "Methods for aligning embeddings across languages.",
+        position: [9, 2, -1]
+      },
+      {
+        title: "Temporal Embeddings",
+        abstract: "Captures evolving semantics through time-sensitive vectors.",
+        position: [11, -3, 2]
+      }
     ]
   },
-  { 
+  {
     name: "Leadership",
     position: [-4, -4, -2],
     papers: [
-      { title: "Team Dynamics", position: [-6, -6, -4] },
-      { title: "Leadership Styles", position: [-2, -3, 0] },
-      { title: "Organizational Behavior", position: [-8, -2, -1] }
+      {
+        title: "Team Dynamics",
+        abstract: "Analyzes group interaction patterns impacting performance.",
+        position: [-6, -6, -4]
+      },
+      {
+        title: "Leadership Styles",
+        abstract: "Explores transformational vs transactional leadership modes.",
+        position: [-2, -3, 0]
+      },
+      {
+        title: "Organizational Behavior",
+        abstract: "Studies how structure influences leadership outcomes.",
+        position: [-8, -2, -1]
+      },
+      {
+        title: "Remote Leadership",
+        abstract: "Addresses challenges of leading distributed teams.",
+        position: [-5, -5, 1]
+      },
+      {
+        title: "Adaptive Strategy",
+        abstract: "Outlines responsive leadership during change.",
+        position: [-3, -6, -2]
+      }
     ]
   },
-  { 
+  {
     name: "Consciousness",
     position: [4, 2, -4],
     papers: [
-      { title: "Theories of Mind", position: [6, 4, -6] },
-      { title: "Cognitive Science", position: [2, 0, -2] },
-      { title: "Phenomenal Experience", position: [8, 1, -3] }
+      {
+        title: "Theories of Mind",
+        abstract: "Reviews philosophical and scientific views of awareness.",
+        position: [6, 4, -6]
+      },
+      {
+        title: "Cognitive Science",
+        abstract: "Integrates findings on mental processes and consciousness.",
+        position: [2, 0, -2]
+      },
+      {
+        title: "Phenomenal Experience",
+        abstract: "Focuses on subjective qualities of conscious states.",
+        position: [8, 1, -3]
+      },
+      {
+        title: "Neural Correlates",
+        abstract: "Examines brain activity patterns linked to experience.",
+        position: [5, 3, -5]
+      },
+      {
+        title: "Global Workspace Models",
+        abstract: "Describes frameworks for unified conscious processing.",
+        position: [7, 2, -7]
+      }
     ]
   },
-  { 
+  {
     name: "Cognition",
     position: [-6, 0, 4],
     papers: [
-      { title: "Memory Systems", position: [-8, 2, 6] },
-      { title: "Cognitive Models", position: [-4, -2, 3] },
-      { title: "Learning & Memory", position: [-9, 1, 2] }
+      {
+        title: "Memory Systems",
+        abstract: "Overview of short-term and long-term memory mechanisms.",
+        position: [-8, 2, 6]
+      },
+      {
+        title: "Cognitive Models",
+        abstract: "Presents computational models of reasoning.",
+        position: [-4, -2, 3]
+      },
+      {
+        title: "Learning & Memory",
+        abstract: "Links learning theory with memory formation.",
+        position: [-9, 1, 2]
+      },
+      {
+        title: "Decision Making",
+        abstract: "Discusses cognitive factors in choosing actions.",
+        position: [-5, -1, 4]
+      },
+      {
+        title: "Attention Mechanisms",
+        abstract: "Investigates how attention guides perception.",
+        position: [-7, 0, 5]
+      }
     ]
   },
-  { 
+  {
     name: "Emergence",
     position: [0, -2, -4],
     papers: [
-      { title: "Complex Systems", position: [2, -4, -6] },
-      { title: "Emergent Behavior", position: [-2, -1, -2] },
-      { title: "Self-Organization", position: [4, -3, -3] }
+      {
+        title: "Complex Systems",
+        abstract: "Introduces principles of complex adaptive systems.",
+        position: [2, -4, -6]
+      },
+      {
+        title: "Emergent Behavior",
+        abstract: "Explores how simple rules lead to rich behaviors.",
+        position: [-2, -1, -2]
+      },
+      {
+        title: "Self-Organization",
+        abstract: "Describes spontaneous order in decentralized systems.",
+        position: [4, -3, -3]
+      },
+      {
+        title: "Collective Intelligence",
+        abstract: "Studies intelligence arising from group interaction.",
+        position: [1, -2, -5]
+      },
+      {
+        title: "Pattern Formation",
+        abstract: "Analyzes repeating structures emerging in nature.",
+        position: [3, -5, -4]
+      }
     ]
   }
 ]
@@ -146,6 +279,7 @@ export default function TopicWords({ topics, onFocus, focusedTopic }: TopicWords
                 <Paper
                   key={paper.title}
                   title={paper.title}
+                  abstract={paper.abstract}
                   position={paper.position}
                   isVisible={focusedTopic === topic.name}
                   topicPosition={topic.position}


### PR DESCRIPTION
## Summary
- expand each topic with additional papers
- store abstract text for every paper
- pass abstract prop to `Paper` component
- mention paper previews in the README

## Testing
- `npm install` *(fails: no internet)*
- `npm run lint` *(fails: `next` not found)*